### PR TITLE
Handle ErrorKind::Interrupted when doing stream IO

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.2, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 92.8, "exclude_path": "", "crate_features": ""}


### PR DESCRIPTION
When doing IO with the underlying stream object, we should handle
the special case of ErrorKind::Interrupted, otherwise the connection
will be closed incorrectly.

Quotation from Rust doc:
An error of the [`ErrorKind::Interrupted`] kind is non-fatal and the
read operation should be retried if there is nothing else to do.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
