### PR TITLE
Add support for HTTP Delete method

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.4, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 92.5, "exclude_path": "", "crate_features": ""}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -150,6 +150,8 @@ pub enum Method {
     Put,
     /// PATCH Method.
     Patch,
+    /// Delete Method.
+    Delete,
 }
 
 impl Method {
@@ -165,6 +167,7 @@ impl Method {
             b"GET" => Ok(Method::Get),
             b"PUT" => Ok(Method::Put),
             b"PATCH" => Ok(Method::Patch),
+            b"DELETE" => Ok(Method::Delete),
             _ => Err(RequestError::InvalidHttpMethod("Unsupported HTTP method.")),
         }
     }
@@ -175,6 +178,7 @@ impl Method {
             Method::Get => b"GET",
             Method::Put => b"PUT",
             Method::Patch => b"PATCH",
+            Method::Delete => b"DELETE",
         }
     }
 
@@ -184,6 +188,7 @@ impl Method {
             Method::Get => "GET",
             Method::Put => "PUT",
             Method::Patch => "PATCH",
+            Method::Delete => "DELETE",
         }
     }
 }
@@ -281,11 +286,13 @@ mod tests {
         assert_eq!(Method::Get.raw(), b"GET");
         assert_eq!(Method::Put.raw(), b"PUT");
         assert_eq!(Method::Patch.raw(), b"PATCH");
+        assert_eq!(Method::Delete.raw(), b"DELETE");
 
         // Tests for try_from
         assert_eq!(Method::try_from(b"GET").unwrap(), Method::Get);
         assert_eq!(Method::try_from(b"PUT").unwrap(), Method::Put);
         assert_eq!(Method::try_from(b"PATCH").unwrap(), Method::Patch);
+        assert_eq!(Method::try_from(b"DELETE").unwrap(), Method::Delete);
         assert_eq!(
             Method::try_from(b"POST").unwrap_err(),
             RequestError::InvalidHttpMethod("Unsupported HTTP method.")
@@ -387,5 +394,8 @@ mod tests {
 
         let val = Method::Patch;
         assert_eq!(val.to_str(), "PATCH");
+
+        let val = Method::Delete;
+        assert_eq!(val.to_str(), "DELETE");
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -131,13 +131,10 @@ impl<T: Read + Write> ClientConnection<T> {
 
                 // Send an error response for the request that gave us the error.
                 let mut error_response = Response::new(Version::Http11, StatusCode::BadRequest);
-                error_response.set_body(Body::new(
-                    format!(
-                        "{{ \"error\": \"{}\nAll previous unanswered requests will be dropped.\" }}",
-                        inner.to_string()
-                    )
-                    .to_string(),
-                ));
+                error_response.set_body(Body::new(format!(
+                    "{{ \"error\": \"{}\nAll previous unanswered requests will be dropped.\" }}",
+                    inner.to_string()
+                )));
                 self.connection.enqueue_response(error_response);
             }
             Err(ConnectionError::InvalidWrite) => {


### PR DESCRIPTION
Add support for Method::Delete, which is needed for device hot-removal.
Also fix a clippy warning.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
