### PR TITLE
Add http status code 503

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.4, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 92.5, "exclude_path": "", "crate_features": ""}

--- a/src/response.rs
+++ b/src/response.rs
@@ -27,6 +27,8 @@ pub enum StatusCode {
     InternalServerError,
     /// 501, Not Implemented
     NotImplemented,
+    /// 503, Service Unavailable
+    ServiceUnavailable,
 }
 
 impl StatusCode {
@@ -40,6 +42,7 @@ impl StatusCode {
             StatusCode::NotFound => b"404",
             StatusCode::InternalServerError => b"500",
             StatusCode::NotImplemented => b"501",
+            StatusCode::ServiceUnavailable => b"503",
         }
     }
 }
@@ -285,5 +288,6 @@ mod tests {
         assert_eq!(StatusCode::NotFound.raw(), b"404");
         assert_eq!(StatusCode::InternalServerError.raw(), b"500");
         assert_eq!(StatusCode::NotImplemented.raw(), b"501");
+        assert_eq!(StatusCode::ServiceUnavailable.raw(), b"503");
     }
 }


### PR DESCRIPTION
## Reason for This PR
Issue: #14 

## Description of Changes
When we are not capable to provide a certain kind of service, but should be
after some delay. Http server is better to reply status code 503. It is more
suggestive per as to http spec.

```
The server is currently unable to handle the request due to a temporary
overload or scheduled maintenance, which will likely be alleviated after some delay.
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
