### PR TITLE
Add support for HTTP HEAD, POST, DELETE methods are needed to support RESTful API

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.4, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 92.5, "exclude_path": "", "crate_features": ""}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -150,6 +150,8 @@ pub enum Method {
     Put,
     /// PATCH Method.
     Patch,
+    /// Delete Method.
+    Delete,
 }
 
 impl Method {
@@ -165,6 +167,7 @@ impl Method {
             b"GET" => Ok(Method::Get),
             b"PUT" => Ok(Method::Put),
             b"PATCH" => Ok(Method::Patch),
+            b"DELETE" => Ok(Method::Delete),
             _ => Err(RequestError::InvalidHttpMethod("Unsupported HTTP method.")),
         }
     }
@@ -175,6 +178,7 @@ impl Method {
             Method::Get => b"GET",
             Method::Put => b"PUT",
             Method::Patch => b"PATCH",
+            Method::Delete => b"DELETE",
         }
     }
 
@@ -184,6 +188,7 @@ impl Method {
             Method::Get => "GET",
             Method::Put => "PUT",
             Method::Patch => "PATCH",
+            Method::Delete => "DELETE",
         }
     }
 }
@@ -281,11 +286,13 @@ mod tests {
         assert_eq!(Method::Get.raw(), b"GET");
         assert_eq!(Method::Put.raw(), b"PUT");
         assert_eq!(Method::Patch.raw(), b"PATCH");
+        assert_eq!(Method::Delete.raw(), b"DELETE");
 
         // Tests for try_from
         assert_eq!(Method::try_from(b"GET").unwrap(), Method::Get);
         assert_eq!(Method::try_from(b"PUT").unwrap(), Method::Put);
         assert_eq!(Method::try_from(b"PATCH").unwrap(), Method::Patch);
+        assert_eq!(Method::try_from(b"DELETE").unwrap(), Method::Delete);
         assert_eq!(
             Method::try_from(b"POST").unwrap_err(),
             RequestError::InvalidHttpMethod("Unsupported HTTP method.")
@@ -387,5 +394,8 @@ mod tests {
 
         let val = Method::Patch;
         assert_eq!(val.to_str(), "PATCH");
+
+        let val = Method::Delete;
+        assert_eq!(val.to_str(), "DELETE");
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -146,12 +146,16 @@ impl Body {
 pub enum Method {
     /// GET Method.
     Get,
+    /// HEAD Method.
+    Head,
+    /// POST Method.
+    Post,
     /// PUT Method.
     Put,
+    /// DELETE Method.
+    Delete,
     /// PATCH Method.
     Patch,
-    /// Delete Method.
-    Delete,
 }
 
 impl Method {
@@ -165,9 +169,11 @@ impl Method {
     pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
         match bytes {
             b"GET" => Ok(Method::Get),
+            b"HEAD" => Ok(Method::Head),
+            b"POST" => Ok(Method::Post),
             b"PUT" => Ok(Method::Put),
-            b"PATCH" => Ok(Method::Patch),
             b"DELETE" => Ok(Method::Delete),
+            b"PATCH" => Ok(Method::Patch),
             _ => Err(RequestError::InvalidHttpMethod("Unsupported HTTP method.")),
         }
     }
@@ -176,9 +182,11 @@ impl Method {
     pub fn raw(self) -> &'static [u8] {
         match self {
             Method::Get => b"GET",
+            Method::Head => b"HEAD",
+            Method::Post => b"POST",
             Method::Put => b"PUT",
-            Method::Patch => b"PATCH",
             Method::Delete => b"DELETE",
+            Method::Patch => b"PATCH",
         }
     }
 
@@ -186,9 +194,11 @@ impl Method {
     pub fn to_str(self) -> &'static str {
         match self {
             Method::Get => "GET",
+            Method::Head => "HEAD",
+            Method::Post => "POST",
             Method::Put => "PUT",
-            Method::Patch => "PATCH",
             Method::Delete => "DELETE",
+            Method::Patch => "PATCH",
         }
     }
 }
@@ -284,17 +294,21 @@ mod tests {
     fn test_method() {
         // Test for raw
         assert_eq!(Method::Get.raw(), b"GET");
+        assert_eq!(Method::Head.raw(), b"HEAD");
+        assert_eq!(Method::Post.raw(), b"POST");
         assert_eq!(Method::Put.raw(), b"PUT");
-        assert_eq!(Method::Patch.raw(), b"PATCH");
         assert_eq!(Method::Delete.raw(), b"DELETE");
+        assert_eq!(Method::Patch.raw(), b"PATCH");
 
         // Tests for try_from
         assert_eq!(Method::try_from(b"GET").unwrap(), Method::Get);
+        assert_eq!(Method::try_from(b"HEAD").unwrap(), Method::Head);
+        assert_eq!(Method::try_from(b"POST").unwrap(), Method::Post);
         assert_eq!(Method::try_from(b"PUT").unwrap(), Method::Put);
-        assert_eq!(Method::try_from(b"PATCH").unwrap(), Method::Patch);
         assert_eq!(Method::try_from(b"DELETE").unwrap(), Method::Delete);
+        assert_eq!(Method::try_from(b"PATCH").unwrap(), Method::Patch);
         assert_eq!(
-            Method::try_from(b"POST").unwrap_err(),
+            Method::try_from(b"CONNECT").unwrap_err(),
             RequestError::InvalidHttpMethod("Unsupported HTTP method.")
         );
     }
@@ -389,13 +403,19 @@ mod tests {
         let val = Method::Get;
         assert_eq!(val.to_str(), "GET");
 
+        let val = Method::Head;
+        assert_eq!(val.to_str(), "HEAD");
+
+        let val = Method::Post;
+        assert_eq!(val.to_str(), "POST");
+
         let val = Method::Put;
         assert_eq!(val.to_str(), "PUT");
 
-        let val = Method::Patch;
-        assert_eq!(val.to_str(), "PATCH");
-
         let val = Method::Delete;
         assert_eq!(val.to_str(), "DELETE");
+
+        let val = Method::Patch;
+        assert_eq!(val.to_str(), "PATCH");
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -347,7 +347,7 @@ mod tests {
         );
 
         // Test for invalid method.
-        let request_line = b"POST http://localhost/home HTTP/1.0";
+        let request_line = b"CONNECT http://localhost/home HTTP/1.0";
         assert_eq!(
             RequestLine::try_from(request_line).unwrap_err(),
             RequestError::InvalidHttpMethod("Unsupported HTTP method.")

--- a/src/server.rs
+++ b/src/server.rs
@@ -131,13 +131,10 @@ impl<T: Read + Write> ClientConnection<T> {
 
                 // Send an error response for the request that gave us the error.
                 let mut error_response = Response::new(Version::Http11, StatusCode::BadRequest);
-                error_response.set_body(Body::new(
-                    format!(
-                        "{{ \"error\": \"{}\nAll previous unanswered requests will be dropped.\" }}",
-                        inner.to_string()
-                    )
-                    .to_string(),
-                ));
+                error_response.set_body(Body::new(format!(
+                    "{{ \"error\": \"{}\nAll previous unanswered requests will be dropped.\" }}",
+                    inner.to_string()
+                )));
                 self.connection.enqueue_response(error_response);
             }
             Err(ConnectionError::InvalidWrite) => {


### PR DESCRIPTION
## Reason for This PR

#16 #13 

## Description of Changes

Add support for Method::Head, Method::Post, Method::Delete, which is needed for RESTful style API, also update related test cases.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
