### PR TITLE
Enable creating a socket from an existing fd

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.1, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 93.0, "exclude_path": "", "crate_features": ""}


### PR DESCRIPTION
## Reason for This PR

To enable another process to initiate the creation of a server by
preparing the socket so it can immediately be used rather than
polling waiting for the socket on the given path to be created.

## Description of Changes

Allow the creation of the http server's socket from an existing
fd.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
