### PR TITLE
Custom headers

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.0, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 93.1, "exclude_path": "", "crate_features": ""}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@
 //! ```
 //! use micro_http::{Request, Version};
 //!
-//! let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n\r\n").unwrap();
+//! let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\r\n";
+//! let http_request = Request::try_from(request_bytes, None).unwrap();
 //! assert_eq!(http_request.http_version(), Version::Http10);
 //! assert_eq!(http_request.uri().get_abs_path(), "/home");
 //! ```

--- a/src/request.rs
+++ b/src/request.rs
@@ -12,7 +12,7 @@ use crate::headers::Headers;
 // This type represents the RequestLine raw parts: method, uri and version.
 type RequestLineParts<'a> = (&'a [u8], &'a [u8], &'a [u8]);
 
-/// Finds the first occurence of `sequence` in the `bytes` slice.
+/// Finds the first occurrence of `sequence` in the `bytes` slice.
 ///
 /// Returns the starting position of the `sequence` in `bytes` or `None` if the
 /// `sequence` is not found.

--- a/src/response.rs
+++ b/src/response.rs
@@ -263,12 +263,12 @@ impl Response {
         self.body.clone()
     }
 
-    /// Returns the HTTP Version of the response.
+    /// Returns the Content Length of the response.
     pub fn content_length(&self) -> i32 {
         self.headers.content_length
     }
 
-    /// Returns the HTTP Version of the response.
+    /// Returns the Content Type of the response.
     pub fn content_type(&self) -> MediaType {
         self.headers.content_type
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -79,8 +79,8 @@ impl<T: Send> HttpRoutes<T> {
     /// let handler = MockHandler {};
     /// router.add_route(Method::Get, "/func1".to_string(), Box::new(handler)).unwrap();
     ///
-    /// let request =
-    ///     Request::try_from(b"GET http://localhost/api/v1/func1 HTTP/1.1\r\n\r\n").unwrap();
+    /// let request_bytes = b"GET http://localhost/api/v1/func1 HTTP/1.1\r\n\r\n";
+    /// let request = Request::try_from(request_bytes, None).unwrap();
     /// let arg = HandlerArg(true);
     /// let reply = router.handle_http_request(&request, &arg);
     /// assert_eq!(reply.status(), StatusCode::OK);
@@ -148,7 +148,7 @@ mod tests {
             .unwrap();
 
         let request =
-            Request::try_from(b"GET http://localhost/api/v1/func2 HTTP/1.1\r\n\r\n").unwrap();
+            Request::try_from(b"GET http://localhost/api/v1/func2 HTTP/1.1\r\n\r\n", None).unwrap();
         let arg = HandlerArg(true);
         let reply = router.handle_http_request(&request, &arg);
         assert_eq!(reply.status(), StatusCode::NotFound);

--- a/src/server.rs
+++ b/src/server.rs
@@ -765,7 +765,8 @@ mod tests {
             second_server_request.request,
             Request::try_from(
                 b"GET /machine-config HTTP/1.1\r\n\
-            Content-Type: application/json\r\n\r\n"
+            Content-Type: application/json\r\n\r\n",
+                None
             )
             .unwrap()
         );
@@ -989,7 +990,8 @@ mod tests {
             second_server_request.request,
             Request::try_from(
                 b"GET /machine-config HTTP/1.1\r\n\
-            Content-Type: application/json\r\n\r\n"
+            Content-Type: application/json\r\n\r\n",
+                None
             )
             .unwrap()
         );

--- a/src/server.rs
+++ b/src/server.rs
@@ -754,8 +754,7 @@ mod tests {
         second_socket
             .write_all(
                 b"GET /machine-config HTTP/1.1\r\n\
-                                Content-Length: 20\r\n\
-                                Content-Type: application/json\r\n\r\nwhatever second body",
+                                Content-Type: application/json\r\n\r\n",
             )
             .unwrap();
 
@@ -766,8 +765,7 @@ mod tests {
             second_server_request.request,
             Request::try_from(
                 b"GET /machine-config HTTP/1.1\r\n\
-            Content-Length: 20\r\n\
-            Content-Type: application/json\r\n\r\nwhatever second body"
+            Content-Type: application/json\r\n\r\n"
             )
             .unwrap()
         );
@@ -980,8 +978,7 @@ mod tests {
         second_socket
             .write_all(
                 b"GET /machine-config HTTP/1.1\r\n\
-                                Content-Length: 20\r\n\
-                                Content-Type: application/json\r\n\r\nwhatever second body",
+                                Content-Type: application/json\r\n\r\n",
             )
             .unwrap();
 
@@ -992,8 +989,7 @@ mod tests {
             second_server_request.request,
             Request::try_from(
                 b"GET /machine-config HTTP/1.1\r\n\
-            Content-Length: 20\r\n\
-            Content-Type: application/json\r\n\r\nwhatever second body"
+            Content-Type: application/json\r\n\r\n"
             )
             .unwrap()
         );


### PR DESCRIPTION
## Reason for This PR

Firecracker uses Micro Http to parse guest requests to MMDS. Implementing IMDSv2 for MMDS requests requires using custom headers. At the moment, Micro Http allows custom headers to be passed within the requests, but just ignores them. In order to be able to properly implement IMDSv2 in Firecracker, we need a way to forward the custom headers to the backend and process them.

## Description of Changes

Added a map dedicated for custom headers, embedded into the `Headers` struct, that stores the custom header names and values as Strings. The current maximum size of the map is 20.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [X] Any required documentation changes (code and docs) are included in this PR.
- ~[X] Any newly added `unsafe` code is properly documented.~
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
