### PR TITLE
Receive file descriptor along with HTTP request

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.1, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 92.8, "exclude_path": "", "crate_features": ""}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -117,8 +117,10 @@ pub enum ConnectionError {
     InvalidWrite,
     /// The request parsing has failed.
     ParseError(RequestError),
-    /// Could not perform a stream operation successfully.
-    StreamError(std::io::Error),
+    /// Could not perform a read operation from stream successfully.
+    StreamReadError(vmm_sys_util::errno::Error),
+    /// Could not perform a write operation to stream successfully.
+    StreamWriteError(std::io::Error),
 }
 
 impl Display for ConnectionError {
@@ -127,7 +129,8 @@ impl Display for ConnectionError {
             Self::ConnectionClosed => write!(f, "Connection closed."),
             Self::InvalidWrite => write!(f, "Invalid write attempt."),
             Self::ParseError(inner) => write!(f, "Parsing error: {}", inner),
-            Self::StreamError(inner) => write!(f, "Stream error: {}", inner),
+            Self::StreamReadError(inner) => write!(f, "Reading stream error: {}", inner),
+            Self::StreamWriteError(inner) => write!(f, "Writing stream error: {}", inner),
         }
     }
 }
@@ -322,7 +325,10 @@ mod tests {
             match (self, other) {
                 (ParseError(ref e), ParseError(ref other_e)) => e.eq(other_e),
                 (ConnectionClosed, ConnectionClosed) => true,
-                (StreamError(ref e), StreamError(ref other_e)) => {
+                (StreamReadError(ref e), StreamReadError(ref other_e)) => {
+                    format!("{}", e).eq(&format!("{}", other_e))
+                }
+                (StreamWriteError(ref e), StreamWriteError(ref other_e)) => {
                     format!("{}", e).eq(&format!("{}", other_e))
                 }
                 (InvalidWrite, InvalidWrite) => true,
@@ -489,9 +495,9 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                ConnectionError::StreamError(std::io::Error::from_raw_os_error(11))
+                ConnectionError::StreamWriteError(std::io::Error::from_raw_os_error(11))
             ),
-            "Stream error: Resource temporarily unavailable (os error 11)"
+            "Writing stream error: Resource temporarily unavailable (os error 11)"
         );
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fs::File;
 use std::str::from_utf8;
 
 use crate::common::ascii::{CR, CRLF_LEN, LF, SP};
@@ -158,6 +159,8 @@ pub struct Request {
     pub headers: Headers,
     /// The body of the request.
     pub body: Option<Body>,
+    /// The optional file associated with the request.
+    pub file: Option<File>,
 }
 
 impl Request {
@@ -217,6 +220,7 @@ impl Request {
                 request_line,
                 headers: Headers::default(),
                 body: None,
+                file: None,
             }),
             Some(headers_end) => {
                 // Parse the request headers.
@@ -276,6 +280,7 @@ impl Request {
                     request_line,
                     headers,
                     body,
+                    file: None,
                 })
             }
             // If we can't find a CR LF CR LF even though the request should have headers
@@ -444,6 +449,7 @@ mod tests {
                 uri: Uri::new("http://localhost/home"),
             },
             body: None,
+            file: None,
             headers: Headers::default(),
         };
         let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n\


### PR DESCRIPTION
## Reason for This PR

Issue #20 

## Description of Changes

This PR brings the support for receiving an optional file descriptor along with the actual HTTP request sent by the client. This means a consumer of this crate can receive along with any request a file descriptor being sent with the control message mechanism and act accordingly.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
