### PR TITLE
response: add `Unauthorized` status code

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -22,6 +22,8 @@ pub enum StatusCode {
     NoContent,
     /// 400, Bad Request
     BadRequest,
+    /// 401, Unauthorized
+    Unauthorized,
     /// 404, Not Found
     NotFound,
     /// 405, Method Not Allowed
@@ -42,6 +44,7 @@ impl StatusCode {
             Self::OK => b"200",
             Self::NoContent => b"204",
             Self::BadRequest => b"400",
+            Self::Unauthorized => b"401",
             Self::NotFound => b"404",
             Self::MethodNotAllowed => b"405",
             Self::InternalServerError => b"500",
@@ -369,6 +372,7 @@ mod tests {
         assert_eq!(StatusCode::OK.raw(), b"200");
         assert_eq!(StatusCode::NoContent.raw(), b"204");
         assert_eq!(StatusCode::BadRequest.raw(), b"400");
+        assert_eq!(StatusCode::Unauthorized.raw(), b"401");
         assert_eq!(StatusCode::NotFound.raw(), b"404");
         assert_eq!(StatusCode::MethodNotAllowed.raw(), b"405");
         assert_eq!(StatusCode::InternalServerError.raw(), b"500");


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Reason for This PR

IMDSv2 throws `Unauthorized` HTTP status code when token provided inside the `GET` request is not valid, as per [this documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html): 

> Requests without a valid token or with an expired token receive a 401 - Unauthorized HTTP error code

This needs to be replicated inside MMDSv2, as well.

## Description of Changes

Added `Unauthorized` response status code.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
