### PR TITLE
Add support for `Deprecation` HTTP response header

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.9, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 93.1, "exclude_path": "", "crate_features": ""}


### PR DESCRIPTION
## Reason for This PR

We need a standardized way of telling HTTP clients that a resource has been deprecated.

## Description of Changes

This PR adds support for the `Deprecation` HTTP header based on [the Deprecation HTTP header field IETF draft](https://tools.ietf.org/id/draft-dalal-deprecation-header-03.html). Users can set this header in a `Response` to send a
"Deprecation: true" header field back to the requester, signaling that the resource accessed has been deprecated. The timestamp version of this header is not implemented in this PR.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
