### PR TITLE
unix target check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # micro-http
 
-This is a minimal implementation of the
+This is a minimal implementation of the 
 [HTTP/1.0](https://tools.ietf.org/html/rfc1945) and
 [HTTP/1.1](https://www.ietf.org/rfc/rfc2616.txt) protocols. This HTTP
 implementation is stateless thus it does not support chunking or compression.
 
 The micro-http implementation is used in production by Firecracker.
+
+As micro-http uses [`std::os::unix`](https://doc.rust-lang.org/std/os/unix/index.html) this crates only supports Unix-like targets.
 
 ## Contributing
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(not(target_family = "unix"))]
+    std::compile_error!("This crate only supports Unix-like targets");
+}


### PR DESCRIPTION
## Reason for This PR

Currently when attempting to build with a non-unix target you get numerous errors relating to `std::os::unix` not being available.

This is obtuse and annoying.

## Description of Changes

To simply inform the user why these errors are occurring a minimal `build.rs` can be added, which produces a simple error quickly when attempting to build on a non-unix system:
```
PS C:\Users\jcawl\Projects\micro-http> cargo build
   Compiling micro_http v0.1.0 (C:\Users\jcawl\Projects\micro-http)
error: This crate only supports unix targets.
 --> build.rs:3:5
  |
3 |     std::compile_error!("This crate only supports unix targets.");
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `micro_http` due to previous error
PS C:\Users\jcawl\Projects\micro-http>
```

As opposed to the previous repetitive messages:
```
PS C:\Users\jcawl\Projects\micro-http> cargo build
   Compiling micro_http v0.1.0 (C:\Users\jcawl\Projects\micro-http)
error[E0433]: failed to resolve: could not find `unix` in `os`
 --> src\connection.rs:7:14
  |
7 | use std::os::unix::io::FromRawFd;
  |              ^^^^ could not find `unix` in `os`

error[E0433]: failed to resolve: could not find `unix` in `os`
 --> src\server.rs:6:14
  |
6 | use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};       
  |              ^^^^ could not find `unix` in `os`

error[E0433]: failed to resolve: could not find `unix` in `os`
 --> src\server.rs:7:14
  |
7 | use std::os::unix::net::{UnixListener, UnixStream};
  |              ^^^^ could not find `unix` in `os`

error[E0432]: unresolved import `vmm_sys_util::sock_ctrl_msg`
  --> src\connection.rs:16:19
   |
16 | use vmm_sys_util::sock_ctrl_msg::ScmSocket;
   |                   ^^^^^^^^^^^^^ could not find `sock_ctrl_msg` in `vmm_sys_util`
error[E0432]: unresolved import `vmm_sys_util::sock_ctrl_msg`
  --> src\server.rs:15:19
   |
15 | use vmm_sys_util::sock_ctrl_msg::ScmSocket;
   |                   ^^^^^^^^^^^^^ could not find `sock_ctrl_msg` in `vmm_sys_util`
error[E0432]: unresolved import `vmm_sys_util::epoll`
  --> src\server.rs:17:5
   |
17 | use vmm_sys_util::epoll;
   |     ^^^^^^^^^^^^^^^^^^^ no `epoll` in the root

error[E0433]: failed to resolve: use of undeclared type `UnixListener`
   --> src\server.rs:276:22
    |
276 |         let socket = UnixListener::bind(path_to_socket).map_err(ServerError::IOError)?;
    |                      ^^^^^^^^^^^^ use of undeclared type `UnixListener`        

error[E0433]: failed to resolve: use of undeclared type `UnixListener`
   --> src\server.rs:297:31
    |
297 |         let socket = unsafe { UnixListener::from_raw_fd(socket_fd) };
    |                               ^^^^^^^^^^^^ use of undeclared type `UnixListener`

error[E0422]: cannot find struct, variant or union type `iovec` in crate `libc`      
   --> src\connection.rs:174:33
    |
174 |         let mut iovecs = [libc::iovec {
    |                                 ^^^^^ not found in `libc`

error[E0412]: cannot find type `UnixListener` in this scope
   --> src\server.rs:255:13
    |
255 |     socket: UnixListener,
    |             ^^^^^^^^^^^^ not found in this scope

error[E0412]: cannot find type `RawFd` in this scope
   --> src\server.rs:263:26
    |
253 | pub struct HttpServer {
    |                      - help: you might be missing a type parameter: `<RawFd>`  
...
263 |     connections: HashMap<RawFd, ClientConnection<UnixStream>>,
    |                          ^^^^^ not found in this scope

error[E0412]: cannot find type `UnixStream` in this scope
   --> src\server.rs:263:50
    |
253 | pub struct HttpServer {
    |                      - help: you might be missing a type parameter: `<UnixStream>`
...
263 |     connections: HashMap<RawFd, ClientConnection<UnixStream>>,
    |                                                  ^^^^^^^^^^ not found in this scope

error[E0412]: cannot find type `RawFd` in this scope
   --> src\server.rs:296:35
    |
296 |     pub fn new_from_fd(socket_fd: RawFd) -> Result<Self> {
    |                                   ^^^^^ not found in this scope

error[E0412]: cannot find type `RawFd` in this scope
   --> src\server.rs:555:36
    |
555 |                     response.id as RawFd,
    |                                    ^^^^^ not found in this scope

error[E0412]: cannot find type `RawFd` in this scope
   --> src\server.rs:603:51
    |
603 |     fn epoll_mod(epoll: &epoll::Epoll, stream_fd: RawFd, evset: epoll::EventSet) -> Result<()> {
    |                                                   ^^^^^ not found in this scope
error[E0412]: cannot find type `RawFd` in this scope
   --> src\server.rs:614:51
    |
614 |     fn epoll_add(epoll: &epoll::Epoll, stream_fd: RawFd) -> Result<()> {
    |                                                   ^^^^^ not found in this scope
error[E0412]: cannot find type `RawFd` in this scope
   --> src\server.rs:628:51
    |
628 |     fn epoll_del(epoll: &epoll::Epoll, stream_fd: RawFd) -> Result<()> {
    |                                                   ^^^^^ not found in this scope
Some errors have detailed explanations: E0412, E0422, E0432, E0433.
For more information about an error, try `rustc --explain E0412`.
error: could not compile `micro_http` due to 17 previo
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
