### PR TITLE
Update rust-vmm/vmm-sys-util and use caret reqs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733537bded03aaa93543f785ae997727b30d1d9f4a03b7861d23290474242e11"
+checksum = "cc06a16ee8ebf0d9269aed304030b0d20a866b8b3dd3d4ce532596ac567a0d24"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-libc = ">=0.2.39"
-vmm-sys-util = ">=0.6.1"
+libc = "0.2.66"
+vmm-sys-util = "0.11.0"


### PR DESCRIPTION
See https://github.com/rust-vmm/community/issues/136

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Reason for This PR

Recently, all rust-vmm crates have received version bumps to fix intra-dependency issues. Now that the rust-vmm side of things is resolved, firecracker should consume all the newly released versions to ensure it itself has a consistent set of dependencies.

## Description of Changes

Updates vmm-sys-util to 0.11.0 and replaces comparison requirements with caret requirements (specific versions of crates were taken from Cargo.lock)

Note that this change will not automatically be consumed into firecracker, as firecracker's micro_http dependency is fixed to commit `0a58eb1`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
