### PR TITLE
Add kill switch functionality

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.5, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 91.9, "exclude_path": "", "crate_features": ""}

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.5, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 91.9, "exclude_path": "", "crate_features": ""}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -166,12 +166,14 @@ pub enum ServerError {
     ConnectionError(ConnectionError),
     /// Epoll operations failed.
     IOError(std::io::Error),
-    /// Overflow occured while processing messages.
+    /// Overflow occurred while processing messages.
     Overflow,
     /// Server maximum capacity has been reached.
     ServerFull,
-    /// Underflow occured while processing mesagges.
+    /// Underflow occurred while processing messages.
     Underflow,
+    /// Shutdown requested.
+    ShutdownEvent,
 }
 
 impl Display for ServerError {
@@ -182,6 +184,7 @@ impl Display for ServerError {
             Self::Overflow => write!(f, "Overflow occured while processing messages."),
             Self::ServerFull => write!(f, "Server is full."),
             Self::Underflow => write!(f, "Underflow occured while processing messages."),
+            Self::ShutdownEvent => write!(f, "Shutdown requested."),
         }
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -170,10 +170,10 @@ pub enum ServerError {
     Overflow,
     /// Server maximum capacity has been reached.
     ServerFull,
-    /// Underflow occurred while processing messages.
-    Underflow,
     /// Shutdown requested.
     ShutdownEvent,
+    /// Underflow occurred while processing messages.
+    Underflow,
 }
 
 impl Display for ServerError {
@@ -343,6 +343,23 @@ mod tests {
                     format!("{}", e).eq(&format!("{}", other_e))
                 }
                 (InvalidWrite, InvalidWrite) => true,
+                _ => false,
+            }
+        }
+    }
+
+    impl PartialEq for ServerError {
+        fn eq(&self, other: &Self) -> bool {
+            use self::ServerError::*;
+            match (self, other) {
+                (ConnectionError(ref e), ConnectionError(ref other_e)) => e.eq(other_e),
+                (IOError(ref e), IOError(ref other_e)) => {
+                    e.raw_os_error() == other_e.raw_os_error()
+                }
+                (Overflow, Overflow) => true,
+                (ServerFull, ServerFull) => true,
+                (ShutdownEvent, ShutdownEvent) => true,
+                (Underflow, Underflow) => true,
                 _ => false,
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1151,11 +1151,11 @@ mod tests {
         handler.join().unwrap();
 
         // Expect shutdown event instead of http request event.
-        match &*request_result.lock().unwrap() {
-            Err(ServerError::ShutdownEvent) => (),
-            v => {
-                panic!("Expected shutdown event, instead got {:?}.", v)
-            }
-        };
+        let res = request_result.lock().unwrap();
+        assert_eq!(
+            res.as_ref().unwrap_err(),
+            &ServerError::ShutdownEvent,
+            "Expected shutdown event, instead got {res:?}"
+        );
     }
 }


### PR DESCRIPTION
Added shutdown event-fd acting as a kill switch actionable from outside the micro-http server.

Needed to be able to break out of the inner epoll_wait on demand.

This can be used to signal the micro-http server running on a dedicated thread that it needs to shut down.
