### PR TITLE
fix: `missing_debug_implementations`

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 87.9, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 85.9, "exclude_path": "", "crate_features": ""}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -19,6 +19,7 @@ const BUFFER_SIZE: usize = 1024;
 const SCM_MAX_FD: usize = 253;
 
 /// Describes the state machine of an HTTP connection.
+#[derive(Debug)]
 enum ConnectionState {
     WaitingForRequestLine,
     WaitingForHeaders,
@@ -27,6 +28,7 @@ enum ConnectionState {
 }
 
 /// A wrapper over a HTTP Connection.
+#[derive(Debug)]
 pub struct HttpConnection<T> {
     /// A partial request that is still being received.
     pending_request: Option<Request>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-#![deny(missing_docs)]
+#![deny(missing_docs, missing_debug_implementations)]
 //! Minimal implementation of the [HTTP/1.0](https://tools.ietf.org/html/rfc1945)
 //! and [HTTP/1.1](https://www.ietf.org/rfc/rfc2616.txt) protocols.
 //!

--- a/src/router.rs
+++ b/src/router.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::hash_map::{Entry, HashMap};
+use std::fmt;
 
 use crate::{MediaType, Method, Request, Response, StatusCode, Version};
 
@@ -22,6 +23,17 @@ pub struct HttpRoutes<T> {
     media_type: MediaType,
     /// routes is a hash table mapping endpoint URIs to their endpoint handlers.
     routes: HashMap<String, Box<dyn EndpointHandler<T> + Sync + Send>>,
+}
+
+impl<T> fmt::Debug for HttpRoutes<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpRoutes")
+            .field("server_id", &self.server_id)
+            .field("prefix", &self.prefix)
+            .field("media_type", &self.media_type)
+            .field("routes", &"{ .. }")
+            .finish()
+    }
 }
 
 impl<T: Send> HttpRoutes<T> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -59,6 +59,7 @@ impl ServerRequest {
 }
 
 /// Wrapper over `Response` which adds an identification token.
+#[derive(Debug)]
 pub struct ServerResponse {
     /// Inner response.
     response: Response,
@@ -74,7 +75,7 @@ impl ServerResponse {
 
 /// Describes the state of the connection as far as data exchange
 /// on the stream is concerned.
-#[derive(PartialOrd, PartialEq)]
+#[derive(Debug, PartialOrd, PartialEq)]
 enum ClientConnectionState {
     AwaitingIncoming,
     AwaitingOutgoing,
@@ -83,6 +84,7 @@ enum ClientConnectionState {
 
 /// Wrapper over `HttpConnection` which keeps track of yielded
 /// requests and absorbed responses.
+#[derive(Debug)]
 struct ClientConnection<T> {
     /// The `HttpConnection` object which handles data exchange.
     connection: HttpConnection<T>,
@@ -249,6 +251,7 @@ impl<T: Read + Write + ScmSocket> ClientConnection<T> {
 ///     break;
 /// }
 /// ```
+#[derive(Debug)]
 pub struct HttpServer {
     /// Socket on which we listen for new connections.
     socket: UnixListener,


### PR DESCRIPTION
## Reason for This PR

It is good for public types to have `std::fmt::Debug` implementations.

## Description of Changes

1. Warns `missing_debug_implementations` lint.
2. Adds `Debug` implementations.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
