### PR TITLE
fix: Always set Content-Length field in non-100/204 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 - Mark `HttpServer::new_from_fd` as `unsafe` as the correctness of the unsafe code
   in this method relies on an invariant the caller has to uphold
+- Always set 'Content-Length' in non-100/204 responses regardless of whether the
+  body is empty. Otherwise, the client waits for the server to close the
+  connection or for timeout to occur.
 
 # v0.1.0
 


### PR DESCRIPTION
## Reason for This PR

Without having 'Content-Length: 0' for an empty content, a client may wait for the server to close the connection or for a timeout to occur like follows:

```
$ curl -s "http://169.254.169.254/latest/meta-data/message" --max-time 5 -v
*   Trying 169.254.169.254:80...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET /latest/meta-data/message HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 
< Server: Firecracker API
< Connection: keep-alive
* no chunk, no close, no size. Assume close to signal end
< 
* Operation timed out after 5001 milliseconds with 0 bytes received
* Closing connection 0
```

With this change, the client can close the connection soon after it gets the response.

```
# curl -s "http://169.254.169.254/latest/meta-data/message" --max-time 5 -v
*   Trying 169.254.169.254:80...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET /latest/meta-data/message HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.81.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200
< Server: Firecracker API
< Connection: keep-alive
< Content-Type: application/json
< Content-Length: 0
<
* Connection #0 to host 169.254.169.254 left intact
```

## Description of Changes

- Always set Content-Length field in non-100/204 responses regardless of whether the body is empty. Although it doesn't cover all the patterns where the response must not set it, users can remove it by calling `set_content_length(None)` if needed.


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- ~~[ ] Any required documentation changes (code and docs) are included in this PR.~~
- ~~[ ] Any newly added `unsafe` code is properly documented.~~
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
