### PR TITLE
Fix Link in headers.rs file to ensure tests pass

### DIFF
--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -435,6 +435,7 @@ mod tests {
     use std::collections::HashMap;
 
     impl Headers {
+        #[allow(missing_docs)]
         pub fn new(content_length: u32, expect: bool, chunked: bool) -> Self {
             Self {
                 content_length,


### PR DESCRIPTION
## Reason for This PR

Cargo tests fail due to test function with no docs

## Description of Changes

common/header.rs 
tests were modified with  #[allow(missing_docs)] on test function