### PR TITLE
response: Add "TooManyRequests" status code

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -30,6 +30,8 @@ pub enum StatusCode {
     MethodNotAllowed,
     /// 413, Payload Too Large
     PayloadTooLarge,
+    /// 429, Too Many Requests
+    TooManyRequests,
     /// 500, Internal Server Error
     InternalServerError,
     /// 501, Not Implemented
@@ -50,6 +52,7 @@ impl StatusCode {
             Self::NotFound => b"404",
             Self::MethodNotAllowed => b"405",
             Self::PayloadTooLarge => b"413",
+            Self::TooManyRequests => b"429",
             Self::InternalServerError => b"500",
             Self::NotImplemented => b"501",
             Self::ServiceUnavailable => b"503",
@@ -448,6 +451,7 @@ mod tests {
         assert_eq!(StatusCode::NotFound.raw(), b"404");
         assert_eq!(StatusCode::MethodNotAllowed.raw(), b"405");
         assert_eq!(StatusCode::PayloadTooLarge.raw(), b"413");
+        assert_eq!(StatusCode::TooManyRequests.raw(), b"429");
         assert_eq!(StatusCode::InternalServerError.raw(), b"500");
         assert_eq!(StatusCode::NotImplemented.raw(), b"501");
         assert_eq!(StatusCode::ServiceUnavailable.raw(), b"503");


### PR DESCRIPTION
## Reason for This PR

The addition of the "TooManyRequests" status code is in order to notify users when an operation is still pending, and this seems to be the best fit we can have for now.

On the Cloud Hypervisor side we'll use it, for instance, for the case when a caller tries to offline a vCPU but the previous offline operation is still pending, leaving at least a chance for the caller to analyse the error and decide whether they want to retry the operation or not.

TooManyRequests: https://datatracker.ietf.org/doc/html/rfc6585#section-4

## Description of Changes

Just added a 429 / TooManyRequests status code.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
