### PR TITLE
feat: Allow to set custom headers in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Added
 
-- Implemented `Eq` for `common::headers::Encoding`, `common::headers::MediaType`, 
+- Implemented `Eq` for `common::headers::Encoding`, `common::headers::MediaType`,
   `common::headers::Headers`, `common::HttpHeaderError`, `common::Body`, `common::Version`,
   `common::RequestError`, `request::Uri`, `request::RequestLine`, `response::StatusCode`,
   `response::ResponseHeaders`
+- Allowed to set custom headers in HTTP responses.
 
 ## Changed
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -23,6 +23,8 @@ pub enum HttpHeaderError {
     InvalidUtf8String(Utf8Error),
     ///The value specified is not valid.
     InvalidValue(String, String),
+    /// Non-ASCII character found.
+    NonAsciiCharacter(String, String),
     /// The content length specified is longer than the limit imposed by Micro Http.
     SizeLimitExceeded(String),
     /// The requested feature is not currently supported.
@@ -44,6 +46,13 @@ impl Display for HttpHeaderError {
             }
             Self::InvalidValue(header_name, value) => {
                 write!(f, "Invalid value. Key:{}; Value:{}", header_name, value)
+            }
+            Self::NonAsciiCharacter(header_name, value) => {
+                write!(
+                    f,
+                    "Non-ASCII character found. Key: {}; Value: {}",
+                    header_name, value
+                )
             }
             Self::SizeLimitExceeded(inner) => {
                 write!(f, "Invalid content length. Header: {}", inner)


### PR DESCRIPTION
## Reason / Changes

EC2 IMDS includes X-Aws-Ec2-Metadata-Token-Ttl-Seconds header in the response to PUT /latest/api/token. To enable Firecracker MMDS to behave compatibly with EC2 IMDS, allow to set custom headers in HTTP response.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- ~~[ ] Any newly added `unsafe` code is properly documented.~~
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
