### PR TITLE
Update to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "micro_http"
 version = "0.1.0"
 license = "Apache-2.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 libc = "0.2.66"

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -343,12 +343,12 @@ mod tests {
         fn eq(&self, other: &Self) -> bool {
             use self::ConnectionError::*;
             match (self, other) {
-                (ParseError(ref e), ParseError(ref other_e)) => e.eq(other_e),
+                (ParseError(e), ParseError(other_e)) => e.eq(other_e),
                 (ConnectionClosed, ConnectionClosed) => true,
-                (StreamReadError(ref e), StreamReadError(ref other_e)) => {
+                (StreamReadError(e), StreamReadError(other_e)) => {
                     format!("{}", e).eq(&format!("{}", other_e))
                 }
-                (StreamWriteError(ref e), StreamWriteError(ref other_e)) => {
+                (StreamWriteError(e), StreamWriteError(other_e)) => {
                     format!("{}", e).eq(&format!("{}", other_e))
                 }
                 (InvalidWrite, InvalidWrite) => true,
@@ -361,8 +361,8 @@ mod tests {
         fn eq(&self, other: &Self) -> bool {
             use self::ServerError::*;
             match (self, other) {
-                (ConnectionError(ref e), ConnectionError(ref other_e)) => e.eq(other_e),
-                (IOError(ref e), IOError(ref other_e)) => {
+                (ConnectionError(e), ConnectionError(other_e)) => e.eq(other_e),
+                (IOError(e), IOError(other_e)) => {
                     e.raw_os_error() == other_e.raw_os_error()
                 }
                 (Overflow, Overflow) => true,

--- a/src/server.rs
+++ b/src/server.rs
@@ -298,7 +298,8 @@ impl HttpServer {
     /// # Errors
     /// Returns an `IOError` when `epoll::create` fails.
     pub unsafe fn new_from_fd(socket_fd: RawFd) -> Result<Self> {
-        let socket = UnixListener::from_raw_fd(socket_fd);
+        // Safety: see the safety contract of this function.
+        let socket = unsafe { UnixListener::from_raw_fd(socket_fd) };
         let epoll = epoll::Epoll::new().map_err(ServerError::IOError)?;
         Ok(HttpServer {
             socket,


### PR DESCRIPTION
## Reason for This PR

Change the Rust edition from 2021 to 2024.

## Description of Changes

Fix build issues and change the edition number.

The changes can be easily squashed into one patch if that's preferred.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
