### PR TITLE
Add support for the HTTP DELETE method

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -244,6 +244,8 @@ pub enum Method {
     Put,
     /// PATCH Method.
     Patch,
+    /// DELETE Method.
+    Delete,
 }
 
 impl Method {
@@ -259,6 +261,7 @@ impl Method {
             b"GET" => Ok(Self::Get),
             b"PUT" => Ok(Self::Put),
             b"PATCH" => Ok(Self::Patch),
+            b"DELETE" => Ok(Self::Delete),
             _ => Err(RequestError::InvalidHttpMethod("Unsupported HTTP method.")),
         }
     }
@@ -269,6 +272,7 @@ impl Method {
             Self::Get => b"GET",
             Self::Put => b"PUT",
             Self::Patch => b"PATCH",
+            Self::Delete => b"DELETE",
         }
     }
 
@@ -278,6 +282,7 @@ impl Method {
             Method::Get => "GET",
             Method::Put => "PUT",
             Method::Patch => "PATCH",
+            Method::Delete => "DELETE",
         }
     }
 }
@@ -398,11 +403,13 @@ mod tests {
         assert_eq!(Method::Get.raw(), b"GET");
         assert_eq!(Method::Put.raw(), b"PUT");
         assert_eq!(Method::Patch.raw(), b"PATCH");
+        assert_eq!(Method::Delete.raw(), b"DELETE");
 
         // Tests for try_from
         assert_eq!(Method::try_from(b"GET").unwrap(), Method::Get);
         assert_eq!(Method::try_from(b"PUT").unwrap(), Method::Put);
         assert_eq!(Method::try_from(b"PATCH").unwrap(), Method::Patch);
+        assert_eq!(Method::try_from(b"DELETE").unwrap(), Method::Delete);
         assert_eq!(
             Method::try_from(b"POST").unwrap_err(),
             RequestError::InvalidHttpMethod("Unsupported HTTP method.")
@@ -587,5 +594,8 @@ mod tests {
 
         let val = Method::Patch;
         assert_eq!(val.to_str(), "PATCH");
+
+        let val = Method::Delete;
+        assert_eq!(val.to_str(), "DELETE");
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -249,7 +249,9 @@ impl Request {
                         None
                     }
                     content_length => {
-                        if request_line.method == Method::Get {
+                        if request_line.method == Method::Get
+                            || request_line.method == Method::Delete
+                        {
                             return Err(RequestError::InvalidRequest);
                         }
                         // Multiplication is safe because `CRLF_LEN` is a small constant.
@@ -476,6 +478,15 @@ mod tests {
 
         // Test for invalid Request (`GET` requests should have no body).
         let request_bytes = b"GET /machine-config HTTP/1.1\r\n\
+                                        Content-Length: 13\r\n\
+                                        Content-Type: application/json\r\n\r\nwhatever body";
+        assert_eq!(
+            Request::try_from(request_bytes, None).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test for invalid Request (`DELETE` requests should have no body).
+        let request_bytes = b"DELETE /machine-config HTTP/1.1\r\n\
                                         Content-Length: 13\r\n\
                                         Content-Type: application/json\r\n\r\nwhatever body";
         assert_eq!(


### PR DESCRIPTION
Add a Delete variant to the Method enum to support DELETE requests. Reject DELETE requests with a body (same as GET requests).

## Reason for This PR

This is needed for the device detach API in Firecracker.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
